### PR TITLE
fix: require relatives to be absolute

### DIFF
--- a/lib/mercadopago.rb
+++ b/lib/mercadopago.rb
@@ -1,24 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
-require_relative './mercadopago/http/http_client'
-
-require_relative './mercadopago/core/mp_base'
-
-require_relative './mercadopago/config/config'
-require_relative './mercadopago/config/request_options'
-
-require_relative './mercadopago/resources/customer'
-require_relative './mercadopago/resources/card'
-require_relative './mercadopago/resources/user'
-require_relative './mercadopago/resources/identification_type'
-require_relative './mercadopago/resources/preference'
-require_relative './mercadopago/resources/payment'
-require_relative './mercadopago/resources/card_token'
-require_relative './mercadopago/resources/refund'
-require_relative './mercadopago/resources/merchant_order'
-require_relative './mercadopago/resources/payment_methods'
-require_relative './mercadopago/resources/advanced_payment'
-require_relative './mercadopago/resources/disbursement_refund'
-
-require_relative './mercadopago/sdk'
+require 'mercadopago/http'
+require 'mercadopago/core'
+require 'mercadopago/conf'
+require 'mercadopago/resources'
+require 'mercadopago/sdk'


### PR DESCRIPTION
This PR attempts to fix the require paths for this gem since bundler is not loading them correctly